### PR TITLE
feat: simplify output

### DIFF
--- a/fileCoverage.test.ts
+++ b/fileCoverage.test.ts
@@ -62,7 +62,7 @@ Deno.test('Parse lines check', async (t) => {
     fc.addLines(22, 0)
       .addLines(23, 0)
       .addLines(24, 0);
-    assertEquals(fc.missingCoverage, '10-11,14,22-24');
+    assertEquals(fc.missingCoverage, '10-11,14-24');
   });
 
   await t.step('Setting Lines Found/Hit', () => {


### PR DESCRIPTION
For large files, the current "Lines Without Coverage" column can get very long.

When for instance lines 1-3 are uncovered, line 4 is empty, and lines 5-7 are uncovered the tool currently outputs 1-3, 5-7.

This PR ignores empty lines when displaying the ranges and outputs 1-7 for this example. This greatly reduces the length of the uncovered lines column for large files making it more readable.